### PR TITLE
Add Qt visualizer for maze algorithms

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,6 @@ CMakeFiles/
 Makefile
 cmake_install.cmake
 MazeProject
+MazeCLI
+MazeVisualizer
 .idea/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,18 +14,25 @@ set(INCLUDE_DIR ${CMAKE_SOURCE_DIR}/include)
 
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_SOURCE_DIR})
 
-
 # Add include directories
 include_directories(${INCLUDE_DIR})
 
-# Find all .cpp and .hpp files in the src and include directories
-file(GLOB_RECURSE SOURCES ${SRC_DIR}/*.cpp)
-file(GLOB_RECURSE HEADERS ${INCLUDE_DIR}/*.hpp)
+# Gather sources for core library
+file(GLOB CORE_SOURCES ${SRC_DIR}/*.cpp)
+list(REMOVE_ITEM CORE_SOURCES ${SRC_DIR}/test.cpp)
 
-# Add the executable target
-add_executable(MazeProject ${SOURCES} ${HEADERS})
+# Core library with algorithms and data structures
+add_library(MazeCore ${CORE_SOURCES})
+target_include_directories(MazeCore PUBLIC ${INCLUDE_DIR})
+
+# Simple CLI executable for manual testing
+add_executable(MazeCLI ${SRC_DIR}/test.cpp)
+target_link_libraries(MazeCLI MazeCore)
+
+# Build the Qt visualizer
+add_subdirectory(visualizer)
 
 # Link libraries or other dependencies if needed (e.g., if you're using any)
 # target_link_libraries(MazeProject <LIBRARY_NAME>)
 
-target_compile_options(MazeProject PRIVATE)
+target_compile_options(MazeCLI PRIVATE)

--- a/src/Algorithms.cpp
+++ b/src/Algorithms.cpp
@@ -2,6 +2,7 @@
 #include <queue>
 #include <climits>
 #include <iostream>
+#include <algorithm>
 
 #define INF std::numeric_limits<double>::max()
 

--- a/src/MazeWithBoxes.cpp
+++ b/src/MazeWithBoxes.cpp
@@ -1,5 +1,6 @@
 
 #include <iomanip>
+#include <algorithm>
 
 //#include <QBrush>
 //#include <QPen>

--- a/visualizer/CMakeLists.txt
+++ b/visualizer/CMakeLists.txt
@@ -1,0 +1,23 @@
+cmake_minimum_required(VERSION 3.10)
+
+set(CMAKE_AUTOMOC ON)
+set(CMAKE_AUTOUIC ON)
+set(CMAKE_AUTORCC ON)
+
+find_package(Qt5 REQUIRED COMPONENTS Widgets)
+
+add_executable(MazeVisualizer
+    main.cpp
+    MainWindow.cpp
+    MazeWidget.cpp
+)
+
+target_link_libraries(MazeVisualizer
+    PRIVATE
+        Qt5::Widgets
+        MazeCore
+)
+
+target_include_directories(MazeVisualizer PRIVATE
+    ${CMAKE_SOURCE_DIR}/include
+)

--- a/visualizer/MainWindow.cpp
+++ b/visualizer/MainWindow.cpp
@@ -1,0 +1,105 @@
+#include "MainWindow.hpp"
+#include "MazeWidget.hpp"
+
+#include <QComboBox>
+#include <QPushButton>
+#include <QVBoxLayout>
+#include <QHBoxLayout>
+
+#include "RandomizedDFS.hpp"
+#include "RecursiveDivision.hpp"
+#include "AdjacencyListGraph.hpp"
+#include "AdjacencyMatrixGraph.hpp"
+#include "Algorithms.hpp"
+#include "MazeGraphRepresentation.hpp"
+#include "MazeCellPredicateStraightLine.hpp"
+#include <memory>
+#include <vector>
+#include <ctime>
+
+MainWindow::MainWindow(QWidget *parent)
+    : QMainWindow(parent)
+{
+    mazeWidget_ = new MazeWidget(this);
+
+    generatorBox_ = new QComboBox(this);
+    generatorBox_->addItem("Randomized DFS");
+    generatorBox_->addItem("Recursive Division");
+
+    graphBox_ = new QComboBox(this);
+    graphBox_->addItem("Adjacency List");
+    graphBox_->addItem("Adjacency Matrix");
+
+    algorithmBox_ = new QComboBox(this);
+    algorithmBox_->addItem("DFS");
+    algorithmBox_->addItem("BFS");
+    algorithmBox_->addItem("Dijkstra");
+    algorithmBox_->addItem("A*");
+
+    runButton_ = new QPushButton("Run", this);
+    connect(runButton_, &QPushButton::clicked, this, &MainWindow::run);
+
+    QWidget *central = new QWidget(this);
+    QVBoxLayout *layout = new QVBoxLayout(central);
+    layout->addWidget(mazeWidget_, 1);
+
+    QHBoxLayout *controls = new QHBoxLayout;
+    controls->addWidget(generatorBox_);
+    controls->addWidget(graphBox_);
+    controls->addWidget(algorithmBox_);
+    controls->addWidget(runButton_);
+    layout->addLayout(controls);
+
+    setCentralWidget(central);
+    setWindowTitle("Maze Visualizer");
+}
+
+void MainWindow::run()
+{
+    int width = 20;
+    int height = 20;
+
+    MazeWithWalls maze(width, height);
+    GenType gen(time(0));
+
+    std::unique_ptr<AbstractMazeGenerator> generator;
+    if (generatorBox_->currentIndex() == 0)
+        generator = std::make_unique<RandomizedDFS>();
+    else
+        generator = std::make_unique<RecursiveDivision>();
+    generator->generate(maze, gen);
+
+    std::unique_ptr<AbstractGraphStorage> graph;
+    if (graphBox_->currentIndex() == 0)
+        graph = std::make_unique<AdjacencyListGraph>(width * height);
+    else
+        graph = std::make_unique<AdjacencyMatrixGraph>(width * height);
+
+    MazeGraphRepresentation mg(&maze, graph.get());
+
+    int start = 0;
+    int end = width * height - 1;
+    std::vector<int> gPath;
+    double cost = 0.0;
+
+    switch (algorithmBox_->currentIndex()) {
+    case 0:
+        dfs(*graph, start, end, gPath, cost);
+        break;
+    case 1:
+        bfs(*graph, start, end, gPath, cost);
+        break;
+    case 2:
+        dijkstra(*graph, start, end, gPath, cost);
+        break;
+    case 3: {
+        MazeCellPredicateStraightLine h(&mg);
+        h.setStart({0,0});
+        h.setTarget({height-1,width-1});
+        aStar(*graph, h, start, end, gPath, cost);
+        break; }
+    }
+
+    std::vector<Cell> mazePath = mg.verticesToCells(gPath);
+    mazeWidget_->setMaze(maze, mazePath);
+}

--- a/visualizer/MainWindow.hpp
+++ b/visualizer/MainWindow.hpp
@@ -1,0 +1,27 @@
+#ifndef MAINWINDOW_HPP
+#define MAINWINDOW_HPP
+
+#include <QMainWindow>
+
+class QComboBox;
+class QPushButton;
+class MazeWidget;
+
+class MainWindow : public QMainWindow
+{
+    Q_OBJECT
+public:
+    explicit MainWindow(QWidget *parent = nullptr);
+
+private slots:
+    void run();
+
+private:
+    MazeWidget *mazeWidget_;
+    QComboBox *generatorBox_;
+    QComboBox *graphBox_;
+    QComboBox *algorithmBox_;
+    QPushButton *runButton_;
+};
+
+#endif // MAINWINDOW_HPP

--- a/visualizer/MazeWidget.cpp
+++ b/visualizer/MazeWidget.cpp
@@ -1,0 +1,80 @@
+#include "MazeWidget.hpp"
+
+#include <QPainter>
+#include <QPaintEvent>
+
+MazeWidget::MazeWidget(QWidget *parent)
+    : QWidget(parent), progressIndex_(0)
+{
+    timer_ = new QTimer(this);
+    connect(timer_, &QTimer::timeout, this, &MazeWidget::advance);
+}
+
+void MazeWidget::setMaze(const MazeWithWalls &maze, const std::vector<Cell> &path)
+{
+    maze_ = std::make_unique<MazeWithWalls>(maze);
+    path_ = path;
+    progressIndex_ = 0;
+    timer_->start(150);
+    update();
+}
+
+QSize MazeWidget::sizeHint() const
+{
+    return QSize(400, 400);
+}
+
+void MazeWidget::advance()
+{
+    if (progressIndex_ < static_cast<int>(path_.size())) {
+        ++progressIndex_;
+        update();
+    } else {
+        timer_->stop();
+    }
+}
+
+void MazeWidget::paintEvent(QPaintEvent *)
+{
+    if (!maze_)
+        return;
+
+    QPainter p(this);
+    p.fillRect(rect(), Qt::white);
+
+    int w = maze_->width();
+    int h = maze_->height();
+    int cellSize = qMin(width() / w, height() / h);
+
+    // draw path progress
+    p.setBrush(Qt::yellow);
+    for (int i = 0; i < progressIndex_; ++i) {
+        const Cell &c = path_[i];
+        QRect r(c.c * cellSize, c.r * cellSize, cellSize, cellSize);
+        p.fillRect(r, Qt::yellow);
+    }
+
+    p.setPen(Qt::black);
+    // draw cell borders
+    for (int y = 0; y < h; ++y) {
+        for (int x = 0; x < w; ++x) {
+            QRect r(x * cellSize, y * cellSize, cellSize, cellSize);
+            p.drawRect(r);
+        }
+    }
+
+    // draw walls
+    p.setPen(QPen(Qt::black, 2));
+    for (int x = 0; x < w; ++x) {
+        for (int y = 0; y < h; ++y) {
+            if (x < w - 1 && maze_->isVerticalWall(x, y)) {
+                int X = (x + 1) * cellSize;
+                p.drawLine(X, y * cellSize, X, (y + 1) * cellSize);
+            }
+            if (y < h - 1 && maze_->isHorizontalWall(x, y)) {
+                int Y = (y + 1) * cellSize;
+                p.drawLine(x * cellSize, Y, (x + 1) * cellSize, Y);
+            }
+        }
+    }
+}

--- a/visualizer/MazeWidget.hpp
+++ b/visualizer/MazeWidget.hpp
@@ -1,0 +1,33 @@
+#ifndef MAZEWIDGET_HPP
+#define MAZEWIDGET_HPP
+
+#include <QWidget>
+#include <QTimer>
+#include <memory>
+#include <vector>
+
+#include "MazeWithWalls.hpp"
+#include "types.hpp"
+
+class MazeWidget : public QWidget
+{
+    Q_OBJECT
+public:
+    explicit MazeWidget(QWidget *parent = nullptr);
+    void setMaze(const MazeWithWalls &maze, const std::vector<Cell> &path);
+    QSize sizeHint() const override;
+
+protected:
+    void paintEvent(QPaintEvent *event) override;
+
+private slots:
+    void advance();
+
+private:
+    std::unique_ptr<MazeWithWalls> maze_;
+    std::vector<Cell> path_;
+    int progressIndex_;
+    QTimer *timer_;
+};
+
+#endif // MAZEWIDGET_HPP

--- a/visualizer/main.cpp
+++ b/visualizer/main.cpp
@@ -1,0 +1,11 @@
+#include <QApplication>
+
+#include "MainWindow.hpp"
+
+int main(int argc, char *argv[])
+{
+    QApplication app(argc, argv);
+    MainWindow w;
+    w.show();
+    return app.exec();
+}


### PR DESCRIPTION
## Summary
- Build core algorithms as `MazeCore` library and expose Qt visualizer module
- Provide GUI to choose maze generators, graph storage, and search algorithms
- Render maze grid with animated path highlighting

## Testing
- `cmake -S . -B build`
- `cmake --build build`


------
https://chatgpt.com/codex/tasks/task_e_689a5f6e2df4832bb8ee9696dec63ef3